### PR TITLE
Separate LIBS & FLAGS

### DIFF
--- a/configure
+++ b/configure
@@ -12838,6 +12838,8 @@ fi
  else
     pkg_failed=untried
 fi
+
+pkg_failed=no
 if test -n "$LIBURING_LIBS"; then
     pkg_cv_LIBURING_LIBS="$LIBURING_LIBS"
  elif test -n "$PKG_CONFIG"; then


### PR DESCRIPTION
Tried to compile, noticed that providing LIBURING_LIBS without LIBURING_FLAGS doesn't work. I guess it would be nice to be able to configure them separately.