### PR TITLE
Override test_kwargs in tap tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2544,6 +2544,10 @@ foreach test: tests
       'env': env,
     }
 
+    if t.has_key('test_kwargs')
+      test_kwargs += t['test_kwargs']
+    endif
+
     foreach onetap : t['tests']
       test(t['name'] / onetap,
         sh,

--- a/src/test/kerberos/meson.build
+++ b/src/test/kerberos/meson.build
@@ -3,6 +3,7 @@ tests += {
   'sd': meson.current_source_dir(),
   'bd': meson.current_build_dir(),
   'tap': {
+    'test_kwargs': {'priority': 40}, # kerberos tests are slow, start early
     'tests': [
       't/001_auth.pl',
     ],


### PR DESCRIPTION
This pr aims to override `tests_kwargs` in tap tests and start `kerberos` tests early since they are slow.
Example run on my local:

|                                                      | real      | user      | sys      |
|------------------------------------------------------|-----------|-----------|----------|
| kwargs is overriden and kerberos tests started early | 3m19.075s | 4m20.296s | 1m7.023s |
| kwargs is overriden                                 | 4m3.891s  | 4m23.065s | 1m7.399s |
| kwargs isn't overriden                             | 4m9.863s  | 4m25.003s | 1m9.155s |

