### PR TITLE
Add ecpg tests to the meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2501,6 +2501,7 @@ subdir('contrib')
 
 subdir('src/test')
 subdir('src/interfaces/libpq/test')
+subdir('src/interfaces/ecpg/test')
 
 subdir('doc/src/sgml')
 
@@ -2601,9 +2602,10 @@ foreach test: tests
   if 'regress' in test
     t = test_default + test['regress']
     test_command = [
-      pg_regress.full_path(),
+      t.get('test_runner', pg_regress).full_path(),
       '--temp-instance', test_result_dir / t['name'] / 'pg_regress' / 'tmp_check',
-      '--inputdir', t['sd'],
+      '--inputdir', t.get('inputdir', t['sd']),
+      '--expecteddir', t.get('expecteddir', t['sd']),
       '--outputdir', test_result_dir / t['name'] / 'pg_regress',
       '--bindir', '',
       '--dlpath', t['bd'],
@@ -2617,7 +2619,8 @@ foreach test: tests
 
     if t.has_key('schedule')
       test_command += ['--schedule', t['schedule'],]
-    else
+    endif
+    if t.has_key('sql')
       test_command += t['sql']
     endif
 

--- a/src/interfaces/ecpg/preproc/meson.build
+++ b/src/interfaces/ecpg/preproc/meson.build
@@ -63,7 +63,7 @@ ecpg_sources += custom_target('ecpg_kwlist_d.h',
   ]
 )
 
-executable('ecpg',
+ecpg_exe = executable('ecpg',
   ecpg_sources,
   include_directories : ['.', ecpg_inc, postgres_inc],
   dependencies: [frontend_shlib_code, libpq],

--- a/src/interfaces/ecpg/test/compat_informix/meson.build
+++ b/src/interfaces/ecpg/test/compat_informix/meson.build
@@ -1,0 +1,31 @@
+pgc_files = [
+  'charfuncs',
+  'dec_test',
+  'describe',
+  'rfmtdate',
+  'rfmtlong',
+  'rnull',
+  'sqlda',
+  'test_informix',
+  'test_informix2',
+]
+
+pgc_extra_flags = {
+  'rnull': ['-r', 'no_indicator',],
+}
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start +
+      ['-C', 'INFORMIX',] +
+      pgc_extra_flags.get(pgc_file, []) +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/compat_oracle/meson.build
+++ b/src/interfaces/ecpg/test/compat_oracle/meson.build
@@ -1,0 +1,18 @@
+pgc_files = [
+  'char_array',
+]
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start + 
+      ['-C', 'ORACLE',] +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/connect/meson.build
+++ b/src/interfaces/ecpg/test/connect/meson.build
@@ -1,0 +1,22 @@
+
+pgc_files = [
+  'test1',
+  'test2',
+  'test3',
+  'test4',
+  'test5',
+]
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/meson.build
+++ b/src/interfaces/ecpg/test/meson.build
@@ -1,0 +1,75 @@
+# TODO: ECPG is not enabled for windows yet
+if host_machine.system() == 'windows'
+  subdir_done()
+endif
+
+pg_regress_ecpg_sources = pg_regress_c + files(
+  'pg_regress_ecpg.c',
+)
+
+pg_regress_ecpg = executable('pg_regress_ecpg',
+  pg_regress_ecpg_sources,
+  c_args: pg_regress_cflags,
+  include_directories: [pg_regress_inc, include_directories('.')],
+  dependencies: [frontend_code],
+  kwargs: default_bin_args + {
+    'install': false
+  },
+)
+
+# create .c files and executables from .pgc files
+ecpg_test_exec_kw = {
+  'dependencies': [frontend_code, libpq],
+  'include_directories': [ecpg_inc],
+  'link_with': [ecpglib, ecpg_compat, ecpg_pgtypes],
+  'build_by_default': false,
+}
+
+ecpg_preproc_test_command_start = [
+  ecpg_exe, 
+  '--regression',
+  '-I@CURRENT_SOURCE_DIR@',
+  '-I@SOURCE_ROOT@' + '/src/interfaces/ecpg/include/',
+]
+ecpg_preproc_test_command_end = [
+  '-o', '@OUTPUT@', '@INPUT@'
+]
+
+ecpg_test_dependencies = []
+
+subdir('connect')
+subdir('sql')
+subdir('pgtypeslib')
+subdir('preproc')
+subdir('compat_informix')
+subdir('compat_oracle')
+subdir('thread')
+
+ecpg_test_files = files(
+  'ecpg_schedule',
+)
+
+ecpg_regress_args = [
+  '--dbname=ecpg1_regression,ecpg2_regression',
+  '--create-role=regress_ecpg_user1,regress_ecpg_user2',
+  '--encoding=SQL_ASCII',
+]
+
+tests += {
+  'name': 'ecpg',
+  'sd': meson.current_source_dir(),
+  'bd': meson.current_build_dir(),
+  'regress': {
+    'test_runner': pg_regress_ecpg,
+    'expecteddir': meson.current_source_dir(),
+    'inputdir': meson.current_build_dir(),
+    'schedule': ecpg_test_files,
+    'sql': [
+      'sql/twophase',
+    ],
+    'test_kwargs': {
+      'depends': ecpg_test_dependencies,
+      },
+    'regress_args': ecpg_regress_args,
+  },
+}

--- a/src/interfaces/ecpg/test/pg_regress_ecpg.c
+++ b/src/interfaces/ecpg/test/pg_regress_ecpg.c
@@ -164,7 +164,7 @@ ecpg_start_test(const char *testname,
 	char	   *appnameenv;
 
 	snprintf(inprg, sizeof(inprg), "%s/%s", inputdir, testname);
-	snprintf(insource, sizeof(insource), "%s.c", testname);
+	snprintf(insource, sizeof(insource), "%s/%s.c", inputdir, testname);
 
 	/* make a version of the test name that has dashes in place of slashes */
 	initStringInfo(&testname_dash);
@@ -177,13 +177,39 @@ ecpg_start_test(const char *testname,
 
 	snprintf(expectfile_stdout, sizeof(expectfile_stdout),
 			 "%s/expected/%s.stdout",
-			 outputdir, testname_dash.data);
+			 expecteddir, testname_dash.data);
+	if (!file_exists(expectfile_stdout))
+		snprintf(expectfile_stdout, sizeof(expectfile_stdout),
+			 	 "%s/expected/%s.stdout",
+				 outputdir, testname_dash.data);
+	if (!file_exists(expectfile_stdout))
+		snprintf(expectfile_stdout, sizeof(expectfile_stdout),
+			 	 "%s/expected/%s.stdout",
+			 	 inputdir, testname_dash.data);
+
 	snprintf(expectfile_stderr, sizeof(expectfile_stderr),
 			 "%s/expected/%s.stderr",
-			 outputdir, testname_dash.data);
+			 expecteddir, testname_dash.data);
+	if (!file_exists(expectfile_stderr))
+		snprintf(expectfile_stderr, sizeof(expectfile_stderr),
+				 "%s/expected/%s.stderr",
+				 outputdir, testname_dash.data);
+	if (!file_exists(expectfile_stderr))
+		snprintf(expectfile_stderr, sizeof(expectfile_stderr),
+			 	 "%s/expected/%s.stderr",
+			 	 inputdir, testname_dash.data);
+
 	snprintf(expectfile_source, sizeof(expectfile_source),
 			 "%s/expected/%s.c",
-			 outputdir, testname_dash.data);
+			 expecteddir, testname_dash.data);
+	if (!file_exists(expectfile_source))
+		snprintf(expectfile_source, sizeof(expectfile_source),
+			 	"%s/expected/%s.c",
+			 	outputdir, testname_dash.data);
+	if (!file_exists(expectfile_source))
+		snprintf(expectfile_source, sizeof(expectfile_source),
+			 	 "%s/expected/%s.c",
+			 	 inputdir, testname_dash.data);
 
 	snprintf(outfile_stdout, sizeof(outfile_stdout),
 			 "%s/results/%s.stdout",

--- a/src/interfaces/ecpg/test/pgtypeslib/meson.build
+++ b/src/interfaces/ecpg/test/pgtypeslib/meson.build
@@ -1,0 +1,21 @@
+pgc_files = [
+  'dt_test',
+  'dt_test2',
+  'num_test',
+  'num_test2',
+  'nan_test',
+]
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/preproc/meson.build
+++ b/src/interfaces/ecpg/test/preproc/meson.build
@@ -1,0 +1,38 @@
+
+pgc_files = [
+  'array_of_struct',
+  'autoprep',
+  'comment',
+  'cursor',
+  'define',
+  'init',
+  'outofscope',
+  'pointer_to_struct',
+  'strings',
+  'type',
+  'variable',
+  'whenever',
+  'whenever_do_continue',
+]
+
+pgc_extra_flags = {
+  'array_of_struct': ['-c'],
+  'pointer_to_struct' : ['-c'],
+  'autoprep': ['-r', 'prepare'],
+  'strings': ['-i'],
+}
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start +
+      pgc_extra_flags.get(pgc_file, []) +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/sql/meson.build
+++ b/src/interfaces/ecpg/test/sql/meson.build
@@ -1,0 +1,46 @@
+pgc_files = [
+  'array',
+  'binary',
+  'bytea',
+  'code100',
+  'copystdout',
+  'createtableas',
+  'declare',
+  'define',
+  'desc',
+  'describe',
+  'dynalloc',
+  'dynalloc2',
+  'dyntest',
+  'execute',
+  'fetch',
+  'func',
+  'indicators',
+  'insupd',
+  'oldexec',
+  'parser',
+  'prepareas',
+  'quote',
+  'show',
+  'sqlda',
+  'twophase',
+]
+
+pgc_extra_flags = {
+  'oldexec': ['-r', 'questionmarks'],
+}
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start + 
+      pgc_extra_flags.get(pgc_file, []) +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw,
+  )
+endforeach

--- a/src/interfaces/ecpg/test/thread/meson.build
+++ b/src/interfaces/ecpg/test/thread/meson.build
@@ -1,0 +1,21 @@
+pgc_files = [
+  'thread_implicit',
+  'thread',
+  'prep',
+  'descriptor',
+  'alloc',
+]
+
+foreach pgc_file: pgc_files
+  exe_input = custom_target(pgc_file,
+    input: '@0@.pgc'.format(pgc_file),
+    output: '@BASENAME@.c',
+    command: ecpg_preproc_test_command_start +
+      ecpg_preproc_test_command_end
+  )
+
+  ecpg_test_dependencies += executable(pgc_file,
+    exe_input,
+    kwargs: ecpg_test_exec_kw + {'dependencies': [frontend_code, libpq, thread_dep,]},
+  )
+endforeach

--- a/src/test/regress/meson.build
+++ b/src/test/regress/meson.build
@@ -1,4 +1,4 @@
-# also used by isolationtester
+# also used by isolationtester and ecpg tests
 pg_regress_c = files('pg_regress.c')
 pg_regress_inc = include_directories('.')
 

--- a/src/test/regress/pg_regress.c
+++ b/src/test/regress/pg_regress.c
@@ -76,6 +76,7 @@ _stringlist *dblist = NULL;
 bool		debug = false;
 char	   *inputdir = ".";
 char	   *outputdir = ".";
+char       *expecteddir = ".";
 char	   *bindir = PGBINDIR;
 char	   *launcher = NULL;
 static _stringlist *loadextension = NULL;
@@ -1989,6 +1990,7 @@ help(void)
 	printf(_("      --debug                   turn on debug mode in programs that are run\n"));
 	printf(_("      --dlpath=DIR              look for dynamic libraries in DIR\n"));
 	printf(_("      --encoding=ENCODING       use ENCODING as the encoding\n"));
+	printf(_("      --expecteddir=DIR         take expected files from DIR (default \".\")\n"));
 	printf(_("  -h, --help                    show this help, then exit\n"));
 	printf(_("      --inputdir=DIR            take input files from DIR (default \".\")\n"));
 	printf(_("      --launcher=CMD            use CMD as launcher of psql\n"));
@@ -2052,6 +2054,7 @@ regression_main(int argc, char *argv[],
 		{"load-extension", required_argument, NULL, 22},
 		{"config-auth", required_argument, NULL, 24},
 		{"max-concurrent-tests", required_argument, NULL, 25},
+		{"expecteddir", required_argument, NULL, 26},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -2181,6 +2184,9 @@ regression_main(int argc, char *argv[],
 			case 25:
 				max_concurrent_tests = atoi(optarg);
 				break;
+			case 26:
+				expecteddir = pg_strdup(optarg);
+				break;				
 			default:
 				/* getopt_long already emitted a complaint */
 				fprintf(stderr, _("\nTry \"%s -h\" for more information.\n"),
@@ -2220,6 +2226,7 @@ regression_main(int argc, char *argv[],
 
 	inputdir = make_absolute_path(inputdir);
 	outputdir = make_absolute_path(outputdir);
+	expecteddir = make_absolute_path(expecteddir);
 	dlpath = make_absolute_path(dlpath);
 
 	/*

--- a/src/test/regress/pg_regress.h
+++ b/src/test/regress/pg_regress.h
@@ -53,6 +53,7 @@ extern _stringlist *dblist;
 extern bool debug;
 extern char *inputdir;
 extern char *outputdir;
+extern char *expecteddir;
 extern char *launcher;
 
 extern const char *basic_diff_opts;


### PR DESCRIPTION
This pr adds ecpg tests.

Steps are:

1. Create `*.c and executables files` from `*.pgc` files (using `ecpg`), done in `test/{test_directory}/meson.build` files.
2. Copy `expected` files from source directory to the build directory.
3. Edit `pg_regress_ecpg.c` so it will try to read `expected files` from `inputdir` if files don't exist in `outputdir`.
4. Create `pg_regress_ecpg` executable in `ecpg/test/meson.build` file.
5. Run tests with `pg_regress_ecpg`.