### PR TITLE
Make cpp flags readable to pg_config

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2263,6 +2263,25 @@ add_project_arguments(cxxflags, language: ['cpp'])
 add_project_arguments(cbflags, language: ['c', 'cpp'])
 add_project_link_arguments(ldflags, language: ['c', 'cpp'])
 
+# set cpp flags
+cpp_flags = {
+  'CC': ' '.join(cc.cmd_array()),
+
+  'CPPFLAGS': ' '.join(g_c_args),
+  'CFLAGS': ' '.join(cbflags + cflags),
+  'CFLAGS_SL': '-fPIC',
+
+  'LDFLAGS': ' '.join(ldflags),
+  'LDFLAGS_EX': '',
+  'LDFLAGS_SL': '',
+
+  'LIBS': '',
+}
+# set VAL_{cpp_flag} for it to be read by pg_config
+foreach flag, value: cpp_flags
+  cdata.set_quoted('VAL_@0@'.format(flag), value)
+endforeach
+
 
 ###############################################################
 # Threading

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,15 +68,15 @@ pgxs_kv = {
   # improve that later.
   'MKDIR_P': ' '.join([install_sh.path(), '-d']),
 
-  'CC': ' '.join(cc.cmd_array()),
+  'CC': cpp_flags['CC'],
   'CPP': ' '.join(cc.cmd_array() + ['-E']),
   'GCC': cc.get_argument_syntax() == 'gcc' ? 'yes' : 'no',
   'with_gnu_ld': (cc.get_linker_id() in ['ld.bfd', 'ld.gold', 'ld.lld'] ? 'yes' : 'no'),
 
-  'CFLAGS': ' '.join(cbflags + cflags),
-  'CPPFLAGS': ' '.join(g_c_args),
+  'CFLAGS': cpp_flags['CFLAGS'],
+  'CPPFLAGS': cpp_flags['CPPFLAGS'],
   'CXXFLAGS': ' '.join(cbflags + cxxflags),
-  'CFLAGS_SL': '-fPIC', #FIXME
+  'CFLAGS_SL': cpp_flags['CFLAGS_SL'], # FIXME:
   'CFLAGS_SL_MOD': cdata.has('HAVE_VISIBILITY_ATTRIBUTE') ? '-fvisibility=hidden' : '',
   'CFLAGS_SSE42': ' '.join(cflags_crc),
   'CFLAGS_UNROLL_LOOPS': ' '.join(unroll_loops_cflags),
@@ -88,9 +88,9 @@ pgxs_kv = {
   'BITCODE_CXXFLAGS': '',
 
   # FIXME:
-  'LDFLAGS': ' '.join(ldflags),
-  'LDFLAGS_EX': '',
-  'LDFLAGS_SL': '',
+  'LDFLAGS': cpp_flags['LDFLAGS'],
+  'LDFLAGS_EX': cpp_flags['LDFLAGS_EX'],
+  'LDFLAGS_SL': cpp_flags['LDFLAGS_SL'],
 
   'BISONFLAGS': ' '.join(bison_flags),
   'FLEXFLAGS': ' '.join(flex_flags),
@@ -99,7 +99,7 @@ pgxs_kv = {
   # that symbol isn't used by postgres, and statically linked, it'll cause an
   # undefined symbol at runtime. And obviously it'll cause problems for
   # executables, although those are probably less common.
-  'LIBS': '',
+  'LIBS': cpp_flags['LIBS'],
 }
 
 if llvm.found()


### PR DESCRIPTION
I used same variables in `pgxs_kv` and didn't move comments from `pgxs_kv`. Are these approaches correct?

current `pg_config` output on my local:

```
...
CONFIGURE = 
CC = ccache cc
CPPFLAGS = -D_GNU_SOURCE
CFLAGS = -D_GNU_SOURCE -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wmissing-prototypes -Wpointer-arith -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wformat-security -Wdeclaration-after-statement -Wno-format-truncation -Wno-stringop-truncation -Wno-clobbered -Wno-missing-field-initializers -Wno-sign-compare -Wno-unused-parameter
CFLAGS_SL = -fPIC
LDFLAGS = 
LDFLAGS_EX = 
LDFLAGS_SL = 
LIBS = 
VERSION = PostgreSQL 15beta1

```