### PR TITLE
find_meson: work with muon

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -232,16 +232,23 @@ if meson_binpath_len < 1
 endif
 
 i = 0
+meson_impl = ''
 meson_binpath = ''
 meson_args = []
 foreach e : meson_binpath_s
   if i == 0
+    meson_impl = e
+  elif i == 1
     meson_binpath = e
   else
     meson_args += e
   endif
   i += 1
 endforeach
+
+if meson_impl not in ['muon', 'meson']
+    error('unknown meson implementation "@0@"'.format(meson_impl))
+endif
 
 meson_bin = find_program(meson_binpath, native: true)
 
@@ -2609,8 +2616,13 @@ test_install_destdir = meson.build_root() / 'tmp_install/'
 test_install_location = test_install_destdir / test_prefix
 
 
+meson_install_args = meson_args + ['install'] + {
+    'meson': ['--quiet', '--only-changed', '--no-rebuild'],
+    'muon': []
+}[meson_impl]
+
 test('tmp_install',
-    meson_bin, args: meson_args + ['install', '--quiet', '--only-changed', '--no-rebuild'],
+    meson_bin, args: meson_install_args ,
     env: {'DESTDIR':test_install_destdir},
     priority: 100,
     is_parallel: false,

--- a/src/tools/find_meson
+++ b/src/tools/find_meson
@@ -4,17 +4,24 @@ import os
 import shlex
 import sys
 
-mesonintrospect = os.environ['MESONINTROSPECT']
-components = shlex.split(mesonintrospect)
+to_print = []
 
-if len(components) < 2:
-    print('expected more than two components, got: %s' % components)
-    sys.exit(1)
+if 'MUON_PATH' in os.environ:
+    to_print += ['muon', os.environ['MUON_PATH']]
+else:
+    mesonintrospect = os.environ['MESONINTROSPECT']
+    components = shlex.split(mesonintrospect)
 
-if components[-1] != 'introspect':
-    print('expected introspection at the end')
-    sys.exit(1)
+    if len(components) < 2:
+        print('expected more than two components, got: %s' % components)
+        sys.exit(1)
 
-print('\n'.join(components[:-1]), end='')
+    if components[-1] != 'introspect':
+        print('expected introspection at the end')
+        sys.exit(1)
+
+    to_print += ['meson'] + components[:-1]
+
+print('\n'.join(to_print), end='')
 
 sys.exit(0)


### PR DESCRIPTION
Use `MUON_PATH` as meson_binpath and also return the meson implementation from `find_meson` so that it can be used later to determine the correct arguments to use.