### PR TITLE
meson: fix: use correct image families for netbsd/openbsd images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,14 +163,14 @@ task:
     - name: NetBSD - 9 - Meson
       only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*\nci-os-only:.*' || $CIRRUS_CHANGE_MESSAGE =~ '.*\nci-os-only:[^\n]*netbsd.*'
       env:
-        IMAGE_NAME: pg-ci-netbsd-9-postgres
+        IMAGE_NAME: pg-ci-netbsd-postgres-9-2
         PLATFORM: netbsd
         INCLUDE_DIRS: -Dextra_lib_dirs=/usr/pkg/lib -Dextra_include_dirs=/usr/pkg/include
 
     - name: OpenBSD - 7 - Meson
       only_if: $CIRRUS_CHANGE_MESSAGE !=~ '.*\nci-os-only:.*' || $CIRRUS_CHANGE_MESSAGE =~ '.*\nci-os-only:[^\n]*openbsd.*'
       env:
-        IMAGE_NAME: pg-ci-openbsd-7-postgres
+        IMAGE_NAME: pg-ci-openbsd-postgres-7-1
         PLATFORM: openbsd
         INCLUDE_DIRS: -Dextra_include_dirs=/usr/local/include -Dextra_lib_dirs=/usr/local/lib
         UUID: -Duuid=e2fs


### PR DESCRIPTION
Applying required changes for https://github.com/anarazel/pg-vm-images/pull/36.

Need to merge https://github.com/anarazel/pg-vm-images/pull/36 first.